### PR TITLE
allow background services with supervisord

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # DOCKER-VERSION 1.0.0
 
 FROM ubuntu:14.04
+
 MAINTAINER Keyvan Fatehi <keyvanfatehi@gmail.com>
 
 RUN apt-get -y update
@@ -19,10 +20,19 @@ RUN chown -R strider /home/strider
 
 # Get the slave
 RUN npm install -g strider-docker-slave@1.*.*
-CMD strider-docker-slave
+
+# Install supervisord
+RUN apt-get -y install supervisor && \
+  mkdir -p /var/log/supervisor && \
+  mkdir -p /etc/supervisor/conf.d
+
+# Run the slave
+# Additional background services can be configured by adding
+# a supervisor config file to the config directory 
+# (/etc/supervisor/conf.d/)
+CMD supervisord -c /etc/supervisor/supervisord.conf && su strider -c 'strider-docker-slave'
 
 WORKDIR /home/strider/workspace
-USER strider
 ENV HOME /home/strider
 
 # Other packages that people might want:

--- a/Readme.md
+++ b/Readme.md
@@ -20,6 +20,33 @@ FROM strider/strider-docker-slave
 
 USER root # so we have permission to install things
 RUN apt-get install -y build-essential default-jre-headless
-USER strider # set the user back to strider at the end
 ```
 
+## Background services
+You can also add Background services to the container.
+This can be done by placing a supervisor config file (a text file
+with the suffix '.conf') for the service into 
+```/etc/supervisor/conf.d/```.
+
+A config file may look like the following:
+```
+[program:dnsmasq]
+command=/usr/sbin/dnsmasq -k
+autostart=true
+autorestart=true
+user=root
+```
+
+### Full example for dnsmasq
+```
+FROM strider/strider-docker-slave
+
+USER root
+RUN apt-get install -y dnsmasq
+# Note: supervisor-dnsmasq.conf is the supervisor config
+# file shown above
+ADD supervisor-dnsmasq.conf /etc/supervisor/conf.d/
+
+# additional configuration of dnsmasq itself
+# [...]
+```


### PR DESCRIPTION
This PR makes it a lot easier to add background services to images which are based on this image.
Also it removes the need to switch back the user to ```strider``` at the end of a Dockerfile
which is based on this one.